### PR TITLE
feat: add The Stall — 210 pay-per-call x402 financial intelligence MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Live services in the [Rail402 marketplace](https://rail402.app/marketplace).
 - [Token Analytics](https://rail402.app/marketplace/token-analytics) — Holder stats, liquidity, price/volume, social mentions, and candlestick signals for a Base token. `0.05 USDC` · Analytics.
 - [Wallet Risk Score](https://rail402.app/marketplace/wallet-risk-score) — 0–1 risk score for an EVM wallet from on-chain behavior. `0.05 USDC` · Security.
 - [Sentiment Summary](https://rail402.app/marketplace/sentiment-summary) — Recent social sentiment for a ticker. `0.02 USDC` · Data.
+- [The Stall](https://the-stall.intuitek.ai) — 178 pay-per-call financial market data capabilities: US stocks, ETFs, equity fundamentals, analyst ratings, insider trades, hedge fund holdings, options chains, treasury yields, DeFi yields, crypto, prediction markets, and macro indicators. `$0.005 USDC/call` · Finance & Market Data.
 
 ## Agent Projects Using Rail402
 


### PR DESCRIPTION
## What this adds

Adds [The Stall](https://the-stall.intuitek.ai) to the **Published APIs** section.

**The Stall** is a live x402 pay-per-call service on Base mainnet with 209 financial market data capabilities: US stocks, ETFs, equity fundamentals, analyst ratings, insider trades, hedge fund holdings, options chains, treasury yields, DeFi yields, crypto, prediction markets, macro indicators, and Korean market movers (Upbit).

- **Endpoint:** https://the-stall.intuitek.ai
- **MCP:** https://the-stall.intuitek.ai/mcp
- **GitHub:** https://github.com/thebrierfox/the-stall
- **Pricing:** ~$0.001-0.024/call in USDC on Base (varies by capability)
- **No API keys** — x402 payment on every call
- Listed on Glama, Smithery, punkpeye/awesome-mcp-servers (PR#7481 pending), and official MCP registry

The Stall uses the same x402/USDC/Base stack that Rail402 is built on — a natural fit for the Published APIs section.

---
_Built by W. Kyle Million (K¹) / IntuiTek¹_
